### PR TITLE
Upgrade deprecated runtime nodejs6.10

### DIFF
--- a/sam/cfn-deploy.yml
+++ b/sam/cfn-deploy.yml
@@ -16,7 +16,7 @@ Resources:
     Type: 'AWS::Lambda::Function'
     Properties:
       Handler: index.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       Code:  
         ZipFile: !Sub |
           let AWS = require('aws-sdk');


### PR DESCRIPTION
CloudFormation templates in aws-serverless-appsync-loyalty have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs6.10). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.